### PR TITLE
Enable warnings as error for windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ add_subdirectory(thirdParty/spdlog)
 
 # Add warning flags for Windows and Linux
 if (WIN32 OR MSVC)
-    add_compile_options(/EHsc /W4)
+    add_compile_options(/EHsc /W4 /WX)
 else()
     add_compile_options(-Wall -Wextra -pedantic -Werror)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ add_subdirectory(thirdParty/spdlog)
 
 # Add warning flags for Windows and Linux
 if (WIN32 OR MSVC)
-    add_compile_options(/EHsc /W4 /WX)
+    add_compile_options(/EHsc /W4 /WX /wd4458)
 else()
     add_compile_options(-Wall -Wextra -pedantic -Werror)
 endif()

--- a/Engine/src/graphics/graphic_manager.cpp
+++ b/Engine/src/graphics/graphic_manager.cpp
@@ -7,10 +7,9 @@
 #include <SDL3/SDL_gpu.h>
 
 void Olaf::GraphicsManager::init(
-    const Options &options, std::shared_ptr<Window> window,
+    [[maybe_unused]] const Options &options, std::shared_ptr<Window> window,
     std::function<void(Options &, GraphicsManager &, const double &)>
         onDrawCallback) {
-    (void)options;
     onDraw = onDrawCallback;
     pWindow = window;
 

--- a/Engine/src/system/window.cpp
+++ b/Engine/src/system/window.cpp
@@ -7,7 +7,7 @@ namespace Olaf {
         if (windowAPI == WindowAPI::SDL3)
             return std::make_shared<WindowSDL3>();
 
-        OLAF_ASSERT("In Olaf::Window::create(WindowAPI windowAPI), no windowAPI seem to be available.", true);
+        OLAF_ASSERT(false, "In Olaf::Window::create(WindowAPI windowAPI), no windowAPI seem to be available.");
         return nullptr;
     }
 }

--- a/application/main.cpp
+++ b/application/main.cpp
@@ -20,21 +20,13 @@ public:
     void onResume() override {
     }
 
-    void onInput(Olaf::Options& options, const double& deltaTime, const std::vector<Olaf::InputAction>& inputActions) override {
-        (void)options;
-        (void)deltaTime;
-        (void)inputActions;
+    void onInput([[maybe_unused]] Olaf::Options& options, [[maybe_unused]] const double& deltaTime, [[maybe_unused]] const std::vector<Olaf::InputAction>& inputActions) override {
     }
 
-    void onUpdate(Olaf::Options& options, const double& deltaTime) override {
-        (void)options;
-        (void)deltaTime;
+    void onUpdate([[maybe_unused]] Olaf::Options& options, [[maybe_unused]] const double& deltaTime) override {
     }
 
-    void onDraw(Olaf::Options& options, Olaf::GraphicsManager& graphicsManager, const double& deltaTime) override {
-        (void)options;
-        (void)graphicsManager;
-        (void)deltaTime;
+    void onDraw([[maybe_unused]] Olaf::Options& options, [[maybe_unused]] Olaf::GraphicsManager& graphicsManager, [[maybe_unused]] const double& deltaTime) override {
     }
 };
 


### PR DESCRIPTION
for windows builds:
- added /WX to the compiles options
- disable compiler warning C4458