### PR TITLE
Resize render targets on window resize

### DIFF
--- a/src/graphics/deferred_gbuffer_renderer.cpp
+++ b/src/graphics/deferred_gbuffer_renderer.cpp
@@ -3,7 +3,6 @@
 #include "../camera.h"
 #include "graphics.h"
 #include "shaders.h"
-#include "texture.h"
 
 #include <SDL3/SDL_log.h>
 
@@ -13,10 +12,6 @@ SDL_AppResult deferred_gbuffer_init(AppState& state) {
     deferred_gbuffer_create_pipelines(state);
     deferred_gbuffer_create_box_geometry(state);
     deferred_gbuffer_create_sphere_geometry(state);
-
-    if (createSolidColorTextureRGBA8(state, DefaultWhite, 32, 32, 1.f, 1.f, 1.f, 1.f) == SDL_APP_FAILURE) [[unlikely]] {
-        return SDL_APP_FAILURE;
-    }
 
     deferred_gbuffer_update_particles(state);
 

--- a/src/graphics/graphics.cpp
+++ b/src/graphics/graphics.cpp
@@ -1,5 +1,6 @@
 #include "graphics.h"
 
+#include "SDL3/SDL_init.h"
 #include "deferred_gbuffer_renderer.h"
 #include "deferred_lighting_renderer.h"
 #include "imguisdl.h"
@@ -19,14 +20,8 @@ SDL_AppResult graphics_init(AppState& state, [[maybe_unused]] int argc, [[maybe_
 
     SDL_GetHintBoolean(SDL_HINT_RENDER_VULKAN_DEBUG, true);
 
-    int w, h;
-    if (!SDL_GetWindowSize(state.window, &w, &h))
-        return SDL_APP_FAILURE;
-
-    createRenderTarget(state, GeometryPosition, w, h, SDL_GPU_TEXTUREFORMAT_R32G32B32A32_FLOAT, SDL_GPU_TEXTUREUSAGE_COLOR_TARGET | SDL_GPU_TEXTUREUSAGE_SAMPLER);
-    createRenderTarget(state, GeometryNormal, w, h, SDL_GPU_TEXTUREFORMAT_R16G16B16A16_FLOAT, SDL_GPU_TEXTUREUSAGE_COLOR_TARGET | SDL_GPU_TEXTUREUSAGE_SAMPLER);
-    createRenderTarget(state, GeometryAlbedo, w, h, SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM, SDL_GPU_TEXTUREUSAGE_COLOR_TARGET | SDL_GPU_TEXTUREUSAGE_SAMPLER);
-    createRenderTarget(state, GeometryDepth, w, h, SDL_GPU_TEXTUREFORMAT_D24_UNORM, SDL_GPU_TEXTUREUSAGE_SAMPLER | SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET);
+    if (SDL_AppResult result = graphics_create_render_targets(state); result != SDL_APP_CONTINUE) [[unlikely]]
+        return result;
 
     imgui_init(state);
     init_sampler_presets(state);
@@ -82,6 +77,32 @@ SDL_AppResult graphics_init(AppState& state, [[maybe_unused]] int argc, [[maybe_
     return SDL_APP_CONTINUE;
 }
 
+SDL_AppResult graphics_create_render_targets(AppState& state) {
+    int w, h;
+    if (!SDL_GetWindowSize(state.window, &w, &h))
+        return SDL_APP_FAILURE;
+
+    int result = SDL_APP_CONTINUE;
+
+    if (state.graphics->textures[GeometryPosition])
+        SDL_ReleaseGPUTexture(state.device, state.graphics->textures[GeometryPosition]);
+    result |= createRenderTarget(state, GeometryPosition, w, h, SDL_GPU_TEXTUREFORMAT_R32G32B32A32_FLOAT, SDL_GPU_TEXTUREUSAGE_COLOR_TARGET | SDL_GPU_TEXTUREUSAGE_SAMPLER);
+
+    if (state.graphics->textures[GeometryNormal])
+        SDL_ReleaseGPUTexture(state.device, state.graphics->textures[GeometryNormal]);
+    result |= createRenderTarget(state, GeometryNormal, w, h, SDL_GPU_TEXTUREFORMAT_R16G16B16A16_FLOAT, SDL_GPU_TEXTUREUSAGE_COLOR_TARGET | SDL_GPU_TEXTUREUSAGE_SAMPLER);
+
+    if (state.graphics->textures[GeometryAlbedo])
+        SDL_ReleaseGPUTexture(state.device, state.graphics->textures[GeometryAlbedo]);
+    result |= createRenderTarget(state, GeometryAlbedo, w, h, SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM, SDL_GPU_TEXTUREUSAGE_COLOR_TARGET | SDL_GPU_TEXTUREUSAGE_SAMPLER);
+
+    if (state.graphics->textures[GeometryDepth])
+        SDL_ReleaseGPUTexture(state.device, state.graphics->textures[GeometryDepth]);
+    result |= createRenderTarget(state, GeometryDepth, w, h, SDL_GPU_TEXTUREFORMAT_D24_UNORM, SDL_GPU_TEXTUREUSAGE_SAMPLER | SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET);
+
+    return (SDL_AppResult)result;
+}
+
 SDL_AppResult graphics_iterate(AppState& state) {
     SDL_GPUCommandBuffer* cmdbuf = SDL_AcquireGPUCommandBuffer(state.device);
     if (cmdbuf == nullptr) [[unlikely]] {
@@ -131,6 +152,11 @@ SDL_AppResult graphics_iterate(AppState& state) {
 
 SDL_AppResult graphics_event(AppState& state, SDL_Event& event) {
     imgui_event(state, event);
+
+    if (event.type == SDL_EVENT_WINDOW_RESIZED) {
+        if (SDL_AppResult result = graphics_create_render_targets(state); result != SDL_APP_CONTINUE) [[unlikely]]
+            return result;
+    }
 
     return SDL_APP_CONTINUE;
 }

--- a/src/graphics/graphics.cpp
+++ b/src/graphics/graphics.cpp
@@ -100,7 +100,7 @@ SDL_AppResult graphics_create_render_targets(AppState& state) {
         SDL_ReleaseGPUTexture(state.device, state.graphics->textures[GeometryDepth]);
     result |= createRenderTarget(state, GeometryDepth, w, h, SDL_GPU_TEXTUREFORMAT_D24_UNORM, SDL_GPU_TEXTUREUSAGE_SAMPLER | SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET);
 
-    return (SDL_AppResult)result;
+    return static_cast<SDL_AppResult>(result);
 }
 
 SDL_AppResult graphics_iterate(AppState& state) {

--- a/src/graphics/graphics.cpp
+++ b/src/graphics/graphics.cpp
@@ -1,6 +1,5 @@
 #include "graphics.h"
 
-#include "SDL3/SDL_init.h"
 #include "deferred_gbuffer_renderer.h"
 #include "deferred_lighting_renderer.h"
 #include "imguisdl.h"
@@ -8,10 +7,14 @@
 
 #include <SDL3/SDL_gpu.h>
 #include <SDL3/SDL_hints.h>
+#include <SDL3/SDL_init.h>
 #include <SDL3/SDL_log.h>
 
-#include <stddef.h>
 #include <imgui_impl_sdlgpu3.h>
+
+#include <stddef.h>
+
+static SDL_AppResult graphics_create_render_targets(AppState& state);
 
 SDL_AppResult graphics_init(AppState& state, [[maybe_unused]] int argc, [[maybe_unused]] char** argv) {
 
@@ -67,7 +70,6 @@ SDL_AppResult graphics_init(AppState& state, [[maybe_unused]] int argc, [[maybe_
     graphics.boxes[0].max[1] = 0.5f;
     graphics.boxes[0].max[2] = 0.5f;
 
-
     if (SDL_AppResult result = deferred_lighting_init(state); result != SDL_APP_CONTINUE) [[unlikely]]
         return result;
 
@@ -77,30 +79,36 @@ SDL_AppResult graphics_init(AppState& state, [[maybe_unused]] int argc, [[maybe_
     return SDL_APP_CONTINUE;
 }
 
-SDL_AppResult graphics_create_render_targets(AppState& state) {
-    int w, h;
-    if (!SDL_GetWindowSize(state.window, &w, &h))
+static SDL_AppResult graphics_create_render_targets(AppState& state) {
+    int width, height;
+    if (!SDL_GetWindowSize(state.window, &width, &height))
         return SDL_APP_FAILURE;
 
-    int result = SDL_APP_CONTINUE;
+    for (SDL_GPUTexture*& texture : state.graphics->textures) {
+        if (texture) {
+            SDL_ReleaseGPUTexture(state.device, texture);
+            texture = nullptr;
+        }
+    }
 
-    if (state.graphics->textures[GeometryPosition])
-        SDL_ReleaseGPUTexture(state.device, state.graphics->textures[GeometryPosition]);
-    result |= createRenderTarget(state, GeometryPosition, w, h, SDL_GPU_TEXTUREFORMAT_R32G32B32A32_FLOAT, SDL_GPU_TEXTUREUSAGE_COLOR_TARGET | SDL_GPU_TEXTUREUSAGE_SAMPLER);
+    SDL_AppResult result;
+    result = createRenderTarget(state, GeometryPosition, width, height, SDL_GPU_TEXTUREFORMAT_R32G32B32A32_FLOAT, SDL_GPU_TEXTUREUSAGE_COLOR_TARGET | SDL_GPU_TEXTUREUSAGE_SAMPLER);
+    if (result != SDL_APP_CONTINUE) [[unlikely]]
+        return result;
 
-    if (state.graphics->textures[GeometryNormal])
-        SDL_ReleaseGPUTexture(state.device, state.graphics->textures[GeometryNormal]);
-    result |= createRenderTarget(state, GeometryNormal, w, h, SDL_GPU_TEXTUREFORMAT_R16G16B16A16_FLOAT, SDL_GPU_TEXTUREUSAGE_COLOR_TARGET | SDL_GPU_TEXTUREUSAGE_SAMPLER);
+    result = createRenderTarget(state, GeometryNormal, width, height, SDL_GPU_TEXTUREFORMAT_R16G16B16A16_FLOAT, SDL_GPU_TEXTUREUSAGE_COLOR_TARGET | SDL_GPU_TEXTUREUSAGE_SAMPLER);
+    if (result != SDL_APP_CONTINUE) [[unlikely]]
+        return result;
 
-    if (state.graphics->textures[GeometryAlbedo])
-        SDL_ReleaseGPUTexture(state.device, state.graphics->textures[GeometryAlbedo]);
-    result |= createRenderTarget(state, GeometryAlbedo, w, h, SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM, SDL_GPU_TEXTUREUSAGE_COLOR_TARGET | SDL_GPU_TEXTUREUSAGE_SAMPLER);
+    result = createRenderTarget(state, GeometryAlbedo, width, height, SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM, SDL_GPU_TEXTUREUSAGE_COLOR_TARGET | SDL_GPU_TEXTUREUSAGE_SAMPLER);
+    if (result != SDL_APP_CONTINUE) [[unlikely]]
+        return result;
 
-    if (state.graphics->textures[GeometryDepth])
-        SDL_ReleaseGPUTexture(state.device, state.graphics->textures[GeometryDepth]);
-    result |= createRenderTarget(state, GeometryDepth, w, h, SDL_GPU_TEXTUREFORMAT_D24_UNORM, SDL_GPU_TEXTUREUSAGE_SAMPLER | SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET);
+    result = createRenderTarget(state, GeometryDepth, width, height, SDL_GPU_TEXTUREFORMAT_D24_UNORM, SDL_GPU_TEXTUREUSAGE_SAMPLER | SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET);
+    if (result != SDL_APP_CONTINUE) [[unlikely]]
+        return result;
 
-    return static_cast<SDL_AppResult>(result);
+    return SDL_APP_CONTINUE;
 }
 
 SDL_AppResult graphics_iterate(AppState& state) {
@@ -143,7 +151,6 @@ SDL_AppResult graphics_iterate(AppState& state) {
     ImGui_ImplSDLGPU3_RenderDrawData(draw_data, cmdbuf, renderPass);
 
     SDL_EndGPURenderPass(renderPass);
-
 
     SDL_SubmitGPUCommandBuffer(cmdbuf);
 

--- a/src/graphics/graphics.cpp
+++ b/src/graphics/graphics.cpp
@@ -81,7 +81,7 @@ SDL_AppResult graphics_init(AppState& state, [[maybe_unused]] int argc, [[maybe_
 
 static SDL_AppResult graphics_create_render_targets(AppState& state) {
     int width, height;
-    if (!SDL_GetWindowSize(state.window, &width, &height))
+    if (!SDL_GetWindowSize(state.window, &width, &height)) [[unlikely]]
         return SDL_APP_FAILURE;
 
     for (SDL_GPUTexture*& texture : state.graphics->textures) {
@@ -105,6 +105,10 @@ static SDL_AppResult graphics_create_render_targets(AppState& state) {
         return result;
 
     result = createRenderTarget(state, GeometryDepth, width, height, SDL_GPU_TEXTUREFORMAT_D24_UNORM, SDL_GPU_TEXTUREUSAGE_SAMPLER | SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET);
+    if (result != SDL_APP_CONTINUE) [[unlikely]]
+        return result;
+
+    result = createSolidColorTextureRGBA8(state, DefaultWhite, 32, 32, 1.f, 1.f, 1.f, 1.f);
     if (result != SDL_APP_CONTINUE) [[unlikely]]
         return result;
 

--- a/src/graphics/graphics.h
+++ b/src/graphics/graphics.h
@@ -11,7 +11,6 @@ union SDL_Event;
 SDL_AppResult graphics_init(AppState& state, int argc, char** argv);
 SDL_AppResult graphics_iterate(AppState& state);
 SDL_AppResult graphics_event(AppState& state, SDL_Event& event);
-SDL_AppResult graphics_create_render_targets(AppState& state);
 void graphics_quit(AppState& state);
 
 enum GraphicPipelineIndex {

--- a/src/graphics/graphics.h
+++ b/src/graphics/graphics.h
@@ -11,6 +11,7 @@ union SDL_Event;
 SDL_AppResult graphics_init(AppState& state, int argc, char** argv);
 SDL_AppResult graphics_iterate(AppState& state);
 SDL_AppResult graphics_event(AppState& state, SDL_Event& event);
+SDL_AppResult graphics_create_render_targets(AppState& state);
 void graphics_quit(AppState& state);
 
 enum GraphicPipelineIndex {


### PR DESCRIPTION
When window is resized, the render targets stay the same, causing problems such as this:

![2025-07-08-172932_1208x805_scrot](https://github.com/user-attachments/assets/369888f4-f7a7-49dc-9a01-f15601166ff6)

Fix:
- Move render target creation into its own function
- On window resize event, destroy and recreate textures