### PR TITLE
Fix/node force accumulation

### DIFF
--- a/boreas/src/mpm.cpp
+++ b/boreas/src/mpm.cpp
@@ -78,7 +78,7 @@ namespace Solver {
             mat3n df(3, v_next.cols());
             df.setZero();
 
-#pragma omp for
+#pragma omp for nowait
             for (size_t i = 0; i < solver.p_current_state.p_position.size(); ++i) {
                 // 3.23 - velocity gradient
                 mat3 velocities_grad = mat3::Zero();
@@ -171,13 +171,14 @@ namespace Solver {
                 master_df += df;
             }
 
+#pragma omp barrier
 #pragma omp for
             for (size_t i = 0; i < solver.grid.active_nodes.size(); ++i) {
                 Av_next.col(i) = v_next.col(i);
                 const auto index = solver.grid.active_nodes[i];
                 const double& node_mass = solver.grid.nodes[index].mass;
                 if (node_mass > EPSILON) [[likely]] {
-                    vec3 df_res = params.beta_integration * simulation_dt * df.col(i) / node_mass;
+                    vec3 df_res = params.beta_integration * simulation_dt * master_df.col(i) / node_mass;
 #pragma omp atomic
                     Av_next.col(i).x() -= df_res.x();
 #pragma omp atomic

--- a/boreas/src/mpm.cpp
+++ b/boreas/src/mpm.cpp
@@ -343,15 +343,8 @@ static void create_particle_state(MpmParticlesState& state,
 }
 
 static inline void reset_nodes(MpmGrid& grid) {
+    memset(static_cast<void*>(grid.nodes.data()), 0, grid.nodes.size() * sizeof(MpmGridNode));
     grid.active_nodes.clear();
-#pragma omp parallel for
-    for (size_t i = 0; i < grid.nodes.size(); ++i) {
-        grid.nodes[i].mass = 0.0;
-        grid.nodes[i].velocity_star.setZero();
-        grid.nodes[i].velocity.setZero();
-        grid.nodes[i].momentum.setZero();
-        grid.nodes[i].force.setZero();
-    }
 }
 
 void MpmSolver::initialize() {

--- a/boreas/src/mpm.cpp
+++ b/boreas/src/mpm.cpp
@@ -404,8 +404,11 @@ void MpmSolver::step1_rasterize_particles_to_grid() {
         for (int z = 0; z < 4; ++z) {
             for (int y = 0; y < 4; ++y) {
                 for (int x = 0; x < 4; ++x) {
-                    if ((base_position.x() + x) < 0 || (base_position.x() + x) >= grid.width || (base_position.y() + y) < 0 || (base_position.y() + y) >= grid.height || (base_position.z() + z) < 0 || (base_position.z() + z) >= grid.depth) [[unlikely]]
-                        continue;
+                    auto weight_id = x + y * 4 + z * 4 * 4;
+                    if ((base_position.x() + x) < 0 || (base_position.x() + x) >= grid.width || (base_position.y() + y) < 0 || (base_position.y() + y) >= grid.height || (base_position.z() + z) < 0 || (base_position.z() + z) >= grid.depth) [[unlikely]] {
+                        p_weights[i][weight_id] = 0.0f;
+                        p_weights_gradient[i][weight_id] = vec3::Zero();
+                    }
 
                     // calculate particle offset
                     size_t node_index = get_node_id_from_local(
@@ -427,7 +430,6 @@ void MpmSolver::step1_rasterize_particles_to_grid() {
                     double dNi_y = d_N(p_off.y());
                     double dNi_z = d_N(p_off.z());
 
-                    auto weight_id = x + y * 4 + z * 4 * 4;
                     double w_ip = p_weights[i][weight_id] = Ni_x * Ni_y * Ni_z;
                     p_weights_gradient[i][weight_id] = grid.one_over_h * vec3(dNi_x * Ni_y * Ni_z, Ni_x * dNi_y * Ni_z, Ni_x * Ni_y * dNi_z);
 

--- a/boreas/src/mpm.cpp
+++ b/boreas/src/mpm.cpp
@@ -449,11 +449,11 @@ void MpmSolver::step1_rasterize_particles_to_grid() {
 #pragma omp atomic
                     node.mass += m_i;
 #pragma omp atomic
-                    node.momentum.x() += momentum.x();
+                    node.velocity.x() += momentum.x();
 #pragma omp atomic
-                    node.momentum.y() += momentum.y();
+                    node.velocity.y() += momentum.y();
 #pragma omp atomic
-                    node.momentum.z() += momentum.z();
+                    node.velocity.z() += momentum.z();
                 }
             }
         }
@@ -464,7 +464,7 @@ void MpmSolver::step1_rasterize_particles_to_grid() {
         // p = mv -> v = p/m
         MpmGridNode& node = grid.nodes[i];
         if (node.mass > EPSILON) [[unlikely]] {
-            node.velocity = node.momentum / node.mass;
+            node.velocity = node.velocity / node.mass;
             grid.active_nodes.push_back(i);
         }
     }

--- a/boreas/src/mpm.hpp
+++ b/boreas/src/mpm.hpp
@@ -31,7 +31,6 @@ struct MpmGridNode {
     double mass { 0.0 }; // m
     vec3 velocity_star = vec3::Zero(); // v
     vec3 velocity = vec3::Zero(); // v*
-    vec3 momentum = vec3::Zero(); // v*
     vec3 force = vec3::Zero(); // F (stress)
 };
 


### PR DESCRIPTION
## Logic
- Small bug in Calculate_Ar, you calculate master_df but never use it.
- Particle weights need (to some extent) to be reset. Otherwise, if a particle is at the extremities of the grid, and the node's position exceeds the grid's boundaries, the previous iteration's weights would still be in the particle's weight array.

## Performance
- Momentum can be removed and its result can be placed in velocity directly. Momentum is only used to calculate velocity anyway.
- I replaced the parallel loop to zero out the grid with a memset. I get better performance on my computer, maybe test with yours.