### PR TITLE
Refactor camera to use yaw and pitch

### DIFF
--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -8,7 +8,7 @@ mat4 CameraPerspective::view_matrix() const {
 }
 
 mat4 CameraPerspective::projection_matrix() const {
-    assert(std::abs(aspectRatio - std::numeric_limits<float>::epsilon()) > 0.f);
+    assert(aspectRatio != 0.f);
     assert(far - near != 0.f);
     const float tanHalfFovy = std::tan(fov / 2.f);
     mat4 m = {};

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -2,17 +2,9 @@
 
 #include <cassert>
 #include <cmath>
-#include <limits>
 
 mat4 CameraPerspective::view_matrix() const {
-    mat4 m;
-    quat const& q = rotation;
-    vec3 p = -position;
-
-    m = mat3_cast(q);
-    m.mm[3] = m.mm[0] * p.x + m.mm[1] * p.y + m.mm[2] * p.z;
-    m[3].w = 1;
-    return m;
+    return lookat(position, position + front, up);
 }
 
 mat4 CameraPerspective::projection_matrix() const {

--- a/src/camera.h
+++ b/src/camera.h
@@ -1,22 +1,16 @@
 #pragma once
-#include "state.h"
+
 #include "vmath.h"
 
 struct CameraPerspective {
-    quat rotation;
+    vec3 front;
+    vec3 right;
+    vec3 up;
     vec3 position;
     float aspectRatio;
     float fov;
     float near;
     float far;
-
-    inline constexpr vec3 right() const {
-        return vec3 {
-            1 - 2 * (rotation.y * rotation.y + rotation.z * rotation.z),
-            2 * (rotation.x * rotation.y + rotation.w * rotation.z),
-            2 * (rotation.x * rotation.z - rotation.w * rotation.y),
-        };
-    }
 
     mat4 view_matrix() const;
     mat4 projection_matrix() const;

--- a/src/controls/controls.cpp
+++ b/src/controls/controls.cpp
@@ -4,13 +4,12 @@
 #include "../vmath.h"
 
 #include <SDL3/SDL_keyboard.h>
+#include <SDL3/SDL_mouse.h>
 
-static inline vec3 rotate_vec3_by_quat(const vec3& v, const quat& q) {
-    // q * v * q^-1
-    quat vq { 0, v.x, v.y, v.z };
-    quat q_inv { q.w, -q.x, -q.y, -q.z };
-    quat result = q * vq * q_inv;
-    return { result.x, result.y, result.z };
+static void set_mouse_capture(AppState& state, bool capture) {
+    state.controls->isCameraCaptured = capture;
+    SDL_SetWindowMouseGrab(state.window, capture);
+    SDL_SetWindowRelativeMouseMode(state.window, capture);
 }
 
 SDL_AppResult controls_init(AppState& state, int argc, char** argv) {
@@ -19,97 +18,108 @@ SDL_AppResult controls_init(AppState& state, int argc, char** argv) {
 
     state.controls = new ControlState {};
     ControlState& controls = *state.controls;
-    controls.cameraTarget = { 0.f, 0.f, 0.f };
+    controls.isCameraCaptured = false;
     controls.movement_speed = 2.5f;
-    controls.mouse_sensitivity = 1.f;
+    controls.mouse_sensitivity = 0.1f;
     controls.distanceFromTarget = state.camera->position.length();
-    controls.isCameraLocked = true;
+    controls.yaw = -180.f;
+    controls.pitch = 0.f;
 
     return SDL_APP_CONTINUE;
 }
 
 SDL_AppResult controls_iterate(AppState& state) {
-    float velocity = state.controls->movement_speed * state.deltaTime;
     bool const* keystate = SDL_GetKeyboardState(nullptr);
 
+    float velocity = state.controls->movement_speed * state.deltaTime;
     if (keystate[SDL_SCANCODE_LCTRL]) {
         velocity *= 10;
     }
     if (keystate[SDL_SCANCODE_A]) {
-        state.camera->position -= velocity * state.deltaTime * mat3_cast(state.camera->rotation)[0];
+        state.camera->position -= velocity * state.camera->right;
     }
     if (keystate[SDL_SCANCODE_D]) {
-        state.camera->position += velocity * state.deltaTime * mat3_cast(state.camera->rotation)[0];
+        state.camera->position += velocity * state.camera->right;
     }
     if (keystate[SDL_SCANCODE_S]) {
-        state.camera->position -= velocity * state.deltaTime * mat3_cast(state.camera->rotation)[2];
+        state.camera->position -= velocity * state.camera->front;
     }
     if (keystate[SDL_SCANCODE_W]) {
-        state.camera->position += velocity * state.deltaTime * mat3_cast(state.camera->rotation)[2];
+        state.camera->position += velocity * state.camera->front;
     }
     if (keystate[SDL_SCANCODE_SPACE]) {
-        state.camera->position += velocity * state.deltaTime * mat3_cast(state.camera->rotation)[1];
+        state.camera->position += velocity * state.camera->up;
     }
     if (keystate[SDL_SCANCODE_LSHIFT]) {
-        state.camera->position -= velocity * state.deltaTime * mat3_cast(state.camera->rotation)[1];
+        state.camera->position -= velocity * state.camera->up;
     }
 
     return SDL_APP_CONTINUE;
 }
 
 SDL_AppResult controls_event(AppState& state, SDL_Event const& event) {
-
     switch (event.type) {
 
     case SDL_EVENT_KEY_DOWN: {
         SDL_KeyboardEvent& evt = (SDL_KeyboardEvent&)event;
-        if (evt.key == SDLK_ESCAPE) [[unlikely]]
+        switch (evt.key) {
+        case SDLK_ESCAPE:
             return SDL_APP_SUCCESS;
+        case SDLK_E:
+            set_mouse_capture(state, !state.controls->isCameraCaptured);
+            return SDL_APP_CONTINUE;
+
+        default:
+            return SDL_APP_CONTINUE;
+        }
+
     } break;
     // Handle Right Mouse Button Click to toggle camera lock
     case SDL_EVENT_MOUSE_BUTTON_DOWN: {
-        SDL_MouseButtonEvent const& evt = (SDL_MouseButtonEvent&)event;
+        SDL_MouseButtonEvent& evt = (SDL_MouseButtonEvent&)event;
         if (evt.button == SDL_BUTTON_RIGHT) {
-            state.controls->isCameraLocked = !state.controls->isCameraLocked;
+            set_mouse_capture(state, !state.controls->isCameraCaptured);
+            return SDL_APP_CONTINUE;
         }
     } break;
     case SDL_EVENT_MOUSE_MOTION: {
-        if (state.controls->isCameraLocked) break; // Ignore camera movement if locked
-
-        SDL_MouseMotionEvent const& evt = (SDL_MouseMotionEvent&)event;
-        float mouse_x, mouse_y;
-        Uint32 mouse_buttons = SDL_GetMouseState(&mouse_x, &mouse_y);
-        // Check if left mouse button is held
-        if (mouse_buttons & SDL_BUTTON_LMASK) {
-
-            vec3 right = state.camera->right();
-            vec3 up = { 0, 1, 0 };
-
-            state.controls->cameraTarget -= right * evt.xrel;
-            state.controls->cameraTarget += up * evt.yrel;
-
-            vec3 offset = rotate_vec3_by_quat(vec3 { 0, 0, state.controls->distanceFromTarget }, state.camera->rotation);
-            state.camera->position = vec3 {
-                state.controls->cameraTarget.x + offset.x,
-                state.controls->cameraTarget.y + offset.y,
-                state.controls->cameraTarget.z + offset.z
-            };
-        } else {
-            // Orbit as before
-            float angle_h = -radians(evt.xrel);
-            float angle_v = -radians(evt.yrel);
-            quat q_h = angleAxis(angle_h, vec3 { 0, 1, 0 });
-            quat q_v = angleAxis(angle_v, state.camera->right());
-
-            state.camera->rotation = q_h * q_v * state.camera->rotation;
-
-            vec3 offset = rotate_vec3_by_quat(vec3 { 0, 0, state.controls->distanceFromTarget }, state.camera->rotation);
-            state.camera->position = vec3 {
-                state.controls->cameraTarget.x + offset.x,
-                state.controls->cameraTarget.y + offset.y,
-                state.controls->cameraTarget.z + offset.z
-            };
+        if (!state.controls->isCameraCaptured) {
+            return SDL_APP_CONTINUE;
         }
+
+        // if (state.controls->isCameraLocked) break; // Ignore camera movement if locked
+        SDL_MouseMotionEvent const& evt = (SDL_MouseMotionEvent&)event;
+
+        float& yaw = state.controls->yaw;
+        float& pitch = state.controls->pitch;
+
+        yaw += evt.xrel * state.controls->mouse_sensitivity;
+        pitch -= evt.yrel * state.controls->mouse_sensitivity;
+
+        if (pitch > 89.f) {
+            pitch = 89.f;
+        } else if (pitch < -89.f) {
+            pitch = -89.f;
+        }
+
+        if (yaw > 180.f){
+            yaw -= 360.f;
+        } else if (yaw < -180.f) {
+            yaw += 360.f;
+        }
+
+        vec3& front = state.camera->front;
+        vec3& right = state.camera->right;
+        vec3& up = state.camera->up;
+
+        front.x = std::cos(radians(yaw)) * std::cos(radians(pitch));
+        front.y = std::sin(radians(pitch));
+        front.z = std::sin(radians(yaw)) * std::cos(radians(pitch));
+
+        front = normalize(front);
+        right = normalize(cross(front, vec3 { 0.f, 1.f, 0.f }));
+        up = normalize(cross(right, front));
+
     } break;
     case SDL_EVENT_MOUSE_WHEEL: {
         SDL_MouseWheelEvent const& evt = (SDL_MouseWheelEvent&)event;

--- a/src/controls/controls.h
+++ b/src/controls/controls.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../state.h"
-#include "../vmath.h"
 
 #include <SDL3/SDL_init.h>
 
@@ -13,9 +12,10 @@ SDL_AppResult controls_event(AppState& state, SDL_Event const& event);
 void controls_quit(AppState& state);
 
 struct ControlState {
-    vec3 cameraTarget;
+    bool isCameraCaptured;
     float movement_speed;
     float mouse_sensitivity;
     float distanceFromTarget;
-    bool isCameraLocked;
+    float yaw;
+    float pitch;
 };

--- a/src/graphics/deferred_lighting_renderer.cpp
+++ b/src/graphics/deferred_lighting_renderer.cpp
@@ -1,6 +1,6 @@
 #include "deferred_lighting_renderer.h"
-#include "shaders.h"
 #include "graphics.h"
+#include "shaders.h"
 
 #include <SDL3/SDL_log.h>
 
@@ -14,10 +14,13 @@ SDL_AppResult deferred_lighting_init(AppState& state) {
     }
     SDL_GPUShader* fsFinal = loadShader(device, SHADER_PATH("deferred_render.frag"), 3, 0, 0, 0);
     if (fsFinal == nullptr) [[unlikely]] {
+        SDL_ReleaseGPUShader(device, vs);
         return SDL_APP_FAILURE;
     }
     SDL_GPUShader* fsDebug = loadShader(device, SHADER_PATH("deferred_debug.frag"), 3, 1, 0, 0);
     if (fsDebug == nullptr) [[unlikely]] {
+        SDL_ReleaseGPUShader(device, vs);
+        SDL_ReleaseGPUShader(device, fsFinal);
         return SDL_APP_FAILURE;
     }
     SDL_GPUVertexInputState vertexInputState = {};
@@ -51,7 +54,7 @@ SDL_AppResult deferred_lighting_init(AppState& state) {
     SDL_ReleaseGPUShader(device, vs);
     SDL_ReleaseGPUShader(device, fsFinal);
     SDL_ReleaseGPUShader(device, fsDebug);
-    
+
     return SDL_APP_CONTINUE;
 }
 
@@ -66,7 +69,6 @@ void deferred_lighting_render_to_texture(
         SDL_LogError(SDL_LOG_CATEGORY_RENDER, "Renderer: Invalid G-buffer textures");
         return;
     }
-
 
     SDL_GPUGraphicsPipeline* pipeline = (mode == DisplayMode::Final) ? gfx.graphicPipeline[DeferredLightingPipeline] : gfx.graphicPipeline[DeferredDebugPipeline];
 
@@ -86,5 +88,4 @@ void deferred_lighting_render_to_texture(
     SDL_PushGPUFragmentUniformData(cmdBuf, 0, &displayMode, sizeof(int));
 
     SDL_DrawGPUPrimitives(renderPass, 3, 1, 0, 0);
-
 }

--- a/src/graphics/imguisdl.cpp
+++ b/src/graphics/imguisdl.cpp
@@ -33,60 +33,20 @@ void imgui_iterate(AppState& state) {
 
     ImGui::Begin("Hello, world!"); // Create a window called "Hello, world!" and append into it.
 
-    ImGui::SliderFloat3("Camera", &state.camera->position.x, -100.0f, 100.0f);
-    if (ImGui::BeginTabBar("MyTabBar", ImGuiTabBarFlags_None)) {
-        if (ImGui::BeginTabItem("Camera Control")) {
+    ImGui::InputFloat3("Camera", &state.camera->position.x);
+    if (ImGui::CollapsingHeader("Controls")) {
+        ImGui::Text("Mouvement State: ");
+        ImGui::SameLine();
 
-            // Camera options table
-            if (ImGui::BeginTable("CameraTable", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg)) {
-                // Lock state row
-                ImGui::TableNextRow();
-                ImGui::TableSetColumnIndex(0);
-                ImGui::Text("Camera Lock");
-                ImGui::TableSetColumnIndex(1);
-                if (state.controls->isCameraLocked) {
-                    ImGui::TextColored(ImVec4(1, 0, 0, 1), "Locked");
-                } else {
-                    ImGui::TextColored(ImVec4(0, 1, 0, 1), "Unlocked");
-                }
-
-                // Camera position row (read-only)
-                ImGui::TableNextRow();
-                ImGui::TableSetColumnIndex(0);
-                ImGui::Text("Position");
-                ImGui::TableSetColumnIndex(1);
-                ImGui::Text("(%.2f, %.2f, %.2f)", state.camera->position.x, state.camera->position.y, state.camera->position.z);
-
-                // Camera target row
-                ImGui::TableNextRow();
-                ImGui::TableSetColumnIndex(0);
-                ImGui::Text("Target");
-                ImGui::TableSetColumnIndex(1);
-                ImGui::Text("(%.2f, %.2f, %.2f)", state.controls->cameraTarget.x, state.controls->cameraTarget.y, state.controls->cameraTarget.z);
-
-                // Camera FOV (optional, for perspective zoom)
-                ImGui::TableNextRow();
-                ImGui::TableSetColumnIndex(0);
-                ImGui::Text("FOV");
-                ImGui::TableSetColumnIndex(1);
-                ImGui::Text("%.2f deg", state.camera->fov * (180.0f / 3.14159265f));
-
-                // Reset button row
-                ImGui::TableNextRow();
-                ImGui::TableSetColumnIndex(0);
-                ImGui::Text("Reset");
-                ImGui::TableSetColumnIndex(1);
-                if (ImGui::Button("Reset Camera")) {
-                    state.controls->cameraTarget = { 0.f, 0.f, 0.f };
-                    state.camera->position = { 0.f, 0.f, 100.f };
-                    state.camera->rotation = { 1.f, 0.f, 0.f, 0.f };
-                }
-
-                ImGui::EndTable();
-            }
-            ImGui::EndTabItem();
-        }
-        ImGui::EndTabBar();
+        if (state.controls->isCameraCaptured)
+            ImGui::TextColored(ImVec4(0.0f, 1.0f, 0.0f, 1.0f), "mouse captured");
+        else
+            ImGui::TextColored(ImVec4(1.0f, 0.0f, 0.0f, 1.0f), "free");
+        ImGui::SliderFloat("Movement Speed", &state.controls->movement_speed, 0.1f, 10.0f);
+        ImGui::SliderFloat("Mouse Sensitivity", &state.controls->mouse_sensitivity, 0.01f, 1.0f);
+        ImGui::SliderFloat("Distance From Target", &state.controls->distanceFromTarget, 0.1f, 100.0f);
+        ImGui::SliderFloat("Yaw", &state.controls->yaw, -180.0f, 180.0f);
+        ImGui::SliderFloat("Pitch", &state.controls->pitch, -89.0f, 89.0f);
     }
 
     ImGui::End();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,13 +81,15 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char **argv) {
     state.numFrames = 0u;
     state.deltaTime = 0.f;
 
-    static const vec3 position { 30, 30, 30 };
+    static const vec3 position { 10,0,0};
     static const vec3 worldUp { 0.f, 1.f, 0.f };
     const vec3 front = normalize(position);
     const vec3 right = normalize(cross(worldUp, front));
     const vec3 up = cross(front, right);
     state.camera = new CameraPerspective {
-        .rotation = quat_cast({ .cols { right, up, front } }),
+        .front = front,
+        .right = right,
+        .up = up,
         .position = position,
         .aspectRatio = static_cast<float>(INITIAL_WINDOW_WIDTH) / static_cast<float>(INITIAL_WINDOW_HEIGHT),
         .fov = radians(75.f),

--- a/src/vmath.h
+++ b/src/vmath.h
@@ -48,6 +48,14 @@ struct alignas(16) vec3 {
         return { -x, -y, -z };
     }
 
+    inline vec3 operator-(const vec3& other) const {
+        return { x - other.x, y - other.y, z - other.z };
+    }
+
+    inline vec3 operator+(const vec3& other) const {
+        return { x + other.x, y + other.y, z + other.z };
+    }
+
     inline vec3& operator+=(vec3 const& v) {
         this->x += v.x;
         this->y += v.y;
@@ -337,6 +345,28 @@ static inline vec4 cross(vec4 const& x, vec4 const& y) {
     vec4 v;
     _mm_store_ps(&v.x, _mm_fmsub_ps(tmp0, tmp1, tmp4));
     return v;
+}
+
+static inline mat4 lookat(vec3 const& eye, vec3 const& center, vec3 const& up) {
+    vec3 const f(normalize(center - eye));
+    vec3 const s(normalize(cross(f, up)));
+    vec3 const u(cross(s, f));
+
+    mat4 m;
+    m[0].x = s.x;
+    m[1].x = s.y;
+    m[2].x = s.z;
+    m[0].y = u.x;
+    m[1].y = u.y;
+    m[2].y = u.z;
+    m[0].z = -f.x;
+    m[1].z = -f.y;
+    m[2].z = -f.z;
+    m[3].x = -dot(s, eye);
+    m[3].y = -dot(u, eye);
+    m[3].z = dot(f, eye);
+
+    return m;
 }
 
 static inline __m128 cross(__m128 const& vec0, __m128 const& vec1) {


### PR DESCRIPTION
L'utilisation de quaternion est finalement une mauvaise idée, c'est bien pour gérer la rotation d'objet, mais pour controler une caméra, la sensation est moins fluide.